### PR TITLE
Fix typo 'classes' -> 'clashes'

### DIFF
--- a/docs/styleguide.rst
+++ b/docs/styleguide.rst
@@ -132,7 +132,7 @@ Naming Conventions
 Protected members are prefixed with a single underscore.  Double
 underscores are reserved for mixin classes.
 
-On classes with keywords, trailing underscores are appended.  Clashes with
+On clashes with keywords, trailing underscores are appended.  Clashes with
 builtins are allowed and **must not** be resolved by appending an
 underline to the variable name.  If the function needs to access a
 shadowed builtin, rebind the builtin to a different name instead.


### PR DESCRIPTION
From context I believe the below is a typo in the readme. I figured this is too small a fix to create an issue for, but can create one if that is required before merging.